### PR TITLE
Dpdk obs

### DIFF
--- a/3rd-party/dpdk/Jenkins/Dockerfile
+++ b/3rd-party/dpdk/Jenkins/Dockerfile
@@ -1,7 +1,17 @@
 FROM openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y git curl gcc libbsd-dev libpcap-dev libcrypto++-dev libjansson4 jq make git-email libnuma-dev gawk python3-pip ninja-build
-RUN python3.5 -m pip install --upgrade meson
+RUN python3 -m pip install --upgrade meson
+
+# SUSE osc install needed for OBS
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository "deb http://download.opensuse.org/repositories/openSUSE:/Tools/Debian_10/ /" \
+    && wget -nv https://download.opensuse.org/repositories/openSUSE:Tools/Debian_10/Release.key -O /root/Release.key \
+    && apt-key add /root/Release.key \
+    && apt-get update \
+    && apt-get install -y osc python-m2crypto libssl-dev swig \
+    && python3 -m pip install M2Crypto
 
 ARG user=jenkins
 ARG group=jenkins

--- a/3rd-party/dpdk/config.xml
+++ b/3rd-party/dpdk/config.xml
@@ -81,6 +81,41 @@
           <defaultValue></defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OBS_USER</name>
+          <description>OBS uploader username</description>
+          <defaultValue></defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.PasswordParameterDefinition>
+          <name>OBS_PASSWORD</name>
+          <description>OBS uploader password</description>
+          <defaultValue></defaultValue>
+        </hudson.model.PasswordParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OBS_TARGET_PROJECT</name>
+          <description>OBS per-series project where the packages will be built</description>
+          <defaultValue></defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OBS_SOURCE_PROJECT</name>
+          <description>OBS project containing the package containing the rpm and deb build files</description>
+          <defaultValue></defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OBS_SOURCE_PACKAGE</name>
+          <description>OBS package containing the rpm and deb build files</description>
+          <defaultValue></defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OBS_GIT_URL</name>
+          <description>Url of the git repository which OBS will clone</description>
+          <defaultValue></defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -154,10 +189,12 @@ if [ -f skip.done ]; then
    exit 0
 fi
 
-if [ &quot;$UPLOAD_GIT_REPO&quot; ]; then
-   git remote add upload_repo &quot;$UPLOAD_GIT_REPO&quot;
+series_branch=series_${SERIES_ID}
+
+if [ &quot;${UPLOAD_GIT_REPO}" ]; then
+   git remote add upload_repo &quot;${UPLOAD_GIT_REPO}&quot;
    git remote update
-   git checkout -b &quot;series_${SERIES_ID}&quot;
+   git checkout -b &quot;${series_branch}&quot;
 fi
 
 #set up checkpatch. checkpatch will check code styling and common spelling errors in comments
@@ -193,7 +230,7 @@ for patch in *.patch; do
        rm tmp.checkpatch.log
 
        if [ &quot;$UPLOAD_GIT_REPO&quot; ]; then
-          git push -u upload_repo &quot;series_${SERIES_ID}&quot;
+          git push -u upload_repo &quot;${series_branch}&quot;
        fi
 
        # now configure the system
@@ -232,6 +269,34 @@ for patch in *.patch; do
       exit_status=1
    fi
 done
+
+# configure OSC
+mkdir -p ~/.config/osc
+cat &lt;&lt; EOF &gt; ~/.config/osc/oscrc
+[general]
+apiurl = https://api.opensuse.org
+build-jobs = 2
+no_verify = 1
+[https://api.opensuse.org]
+aliases = obs
+user=${OBS_USER}
+pass=${OBS_PASSWORD}
+credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+EOF
+
+# branch the original OBS dpdk OBS package
+osc branch ${OBS_SOURCE_PROJECT} ${OBS_SOURCE_PACKAGE} ${OBS_TARGET_PROJECT} ${series_branch}
+# checkout
+osc co ${OBS_TARGET_PROJECT}/${series_branch}
+# don&apos;t publish or use packages for other builds
+#osc api -X POST &quot;/source/${OBS_TARGET_PROJECT}/${series_branch}?cmd=set_flag&amp;flag=publish&amp;status=disable&quot;
+#osc api -X POST &quot;/source/${OBS_TARGET_PROJECT}/${series_branch}?cmd=set_flag&amp;flag=useforbuild&amp;status=disable&quot;
+cd ${OBS_TARGET_PROJECT}/${series_branch}
+# change branch
+sed -i &quot;s#&lt;param name=\&quot;revision\&quot;&gt;.*&lt;/param&gt;#&lt;param name=\&quot;revision\&quot;&gt;${series_branch}&lt;/param&gt;#&quot; _service
+sed -i &quot;s#&lt;param name=\&quot;url\&quot;&gt;.*&lt;/param&gt;#&lt;param name=\&quot;url\&quot;&gt;${OBS_GIT_URL}&lt;/param&gt;#&quot; _service
+# updload the branch - this starts the build
+osc api -X PUT -T _service /source/${OBS_TARGET_PROJECT}/${series_branch}/_service
 
 exit $exit_status</command>
     </hudson.tasks.Shell>

--- a/3rd-party/dpdk/dpdk_obs_alert.sh
+++ b/3rd-party/dpdk/dpdk_obs_alert.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# SPDX-Identifier: gpl-2.0-or-later
+# Copyright (C) 2020 PANTHEON.tech s.r.o.
+#
+# DPDK OBS alert script - monitor OBS builds and report results
+#
+# Licensed under the terms of the GNU General Public License as published
+# by the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.  You may obtain a copy of the
+# license at
+#
+#    https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+./obs_mon patchwork.dpdk.org obs_user obs_password | \
+    grep '^pw|' | while IFS="|" read -r PW series_id result result_details build_url; do
+
+    SERIES_LINE=$(./series_get patchwork.dpdk.org $series_id)
+    url=$(echo $SERIES_LINE | cut -d\| -f3)
+    author=$(echo $SERIES_LINE | cut -d\| -f4)
+    email=$(echo $SERIES_LINE | cut -d\| -f5)
+
+    series_url=$(curl -s $url | jq -rc '.url')
+    series_name=$(curl -s $url | jq -rc '.name')
+
+    if [ "$result" == "succeeded" ]; then
+        RESULT="SUCCESS"
+    elif [ "$result" == "failed" ]; then
+        RESULT="WARNING"
+    else
+        RESULT="ERROR"
+    fi
+
+    echo "To: test-report@dpdk.org" > report.eml
+    echo "From: robot@bytheb.org" >> report.eml
+
+    if [ "$RESULT" != "SUCCESS" ]; then
+        echo "Cc: $author <$email>" >> report.eml
+    fi
+
+    echo "Subject: |$RESULT| pw$series_id $series_name" >> report.eml
+    echo "Date: $(date +"%a, %e %b %Y %T %::z")" >> report.eml
+    echo "" >> report.eml
+
+    echo "Test-Label: obs-robot" >> report.eml
+    echo "Test-Status: $RESULT" >> report.eml
+    echo "$series_url" >> report.eml
+    echo "" >> report.eml
+
+    if [ "${result_details}" != "" ]
+    then
+        echo "Result-Details:" >> report.eml
+        ifs_orig=${IFS}
+        IFS=#
+        for result in ${result_details}
+        do
+            echo "  ${result}" >> report.eml
+        done
+        IFS=${ifs_orig}
+    fi
+
+    echo "Build URL: $build_url" >> report.eml
+
+    cat report.eml
+done

--- a/3rd-party/dpdk/jenkins-rc
+++ b/3rd-party/dpdk/jenkins-rc
@@ -5,5 +5,5 @@ jenkins_token="Insert a token here"
 
 jenkins_DPDK_job=dpdk-job
 jenkins_DPDK_token=authentication-token
-jenkins_DPDK_variables="SERIES_ID:series_id SERIES_URL:series_url SUBMITTER:series_submitter_name SUBMITTER_EMAIL:series_submitter_email ROBO_EMAIL:robot_email SMTP_SERVER:server_host SMTP_USER:username SMTP_PASSWORD:password SMTP_SERVERPORT:port SMTP_ENCRYPTION:(SSL,TLS,STARTTLS,etc.) UPLOAD_GIT_REPO:repo_url"
+jenkins_DPDK_variables="SERIES_ID:series_id SERIES_URL:series_url SUBMITTER:series_submitter_name SUBMITTER_EMAIL:series_submitter_email ROBO_EMAIL:robot_email SMTP_SERVER:server_host SMTP_USER:username SMTP_PASSWORD:password SMTP_SERVERPORT:port SMTP_ENCRYPTION:(SSL,TLS,STARTTLS,etc.) UPLOAD_GIT_REPO:repo_url OBS_USER:user OBS_PASSWORD:password OBS_TARGET_PROJECT:obs_project OBS_SOURCE_PROJECT:home:bluca:dpdk OBS_SOURCE_PACKAGE:dpdk OBS_GIT_URL:https://github.com/ovsrobot/dpdk.git"
 pw_project="DPDK"

--- a/obs_lib.sh
+++ b/obs_lib.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# SPDX-Identifier: gpl-2.0-or-later
+# Copyright (C) 2020 PANTHEON.tech s.r.o.
+#
+# Suse OBS ci library
+#
+# Licensed under the terms of the GNU General Public License as published
+# by the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.  You may obtain a copy of the
+# license at
+#
+#    https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+function obs_results_for_package() {
+    # Prerequisites:
+    # installed osc with credentials stored in ~/.config/osc/oscrc
+    local OBS_PROJECT="$1"
+    shift
+
+    local OBS_PACKAGE="$1"
+    shift
+
+    url="https://build.opensuse.org/package/show/${OBS_PROJECT}/${OBS_PACKAGE}"
+
+    final_result="succeeded"
+
+    failed_found=0
+    scheduled_found=0
+    building_found=0
+    errored_found=0
+    result_details=""
+    while read -r repo arch result
+    do
+        case "${result}" in
+            "scheduled"*)
+                scheduled_found=1
+                ;;
+            "building"*)
+                building_found=1
+                ;;
+            "failed"*)
+                failed_found=1
+                result_details="${result_details}#${repo} ${arch} ${result}"
+                ;;
+            "succeeded"*)
+                ;;
+            "broken"*)
+                # package source is bad (i.e. no specfile), report as error
+                errored_found=1
+                result_details="${result_details}#${repo} ${arch} ${result}"
+                ;;
+            "unresolvable"*)
+                # build needs unavailable binary packages, report as error
+                errored_found=1
+                result_details="${result_details}#${repo} ${arch} ${result}"
+                ;;
+            "*")
+                # disabled: build is disabled in package config
+                # excluded: build is excluded in spec file
+                # these are not failures in series, but OBS (mis)configuration
+                # add them to report, but don't evaluate as error/failure
+                result_details="${result_details}#${repo} ${arch} ${result}"
+                ;;
+        esac
+    done <<< "$(osc results ${OBS_PROJECT} ${OBS_PACKAGE})"
+
+    if [ ${scheduled_found} -eq 1 ]
+    then
+        final_result="scheduled"
+    elif [ ${building_found} -eq 1 ]
+    then
+        final_result="building"
+    elif [ ${errored_found} -eq 1 ]
+    then
+        final_result="errored"
+    elif [ ${failed_found} -eq 1 ]
+    then
+        final_result="failed"
+    fi
+
+    if [[ "${result_details}" == "#"* ]]
+    then
+        result_details="${result_details:1}"
+    fi
+
+    echo "${final_result}|${result_details}|${url}"
+}

--- a/obs_mon
+++ b/obs_mon
@@ -1,0 +1,105 @@
+#!/bin/bash
+# SPDX-Identifier: gpl-2.0-or-later
+# Copyright (C) 2020 PANTHEON.tech s.r.o.
+#
+# Monitors Suse OBS build history for builds in a series
+# Records the builds in the series database (and emits them on the
+# stdout line for processing)
+#
+# The script assumes that the osc OBS utility has been installed
+# Installation instructions:
+# https://software.opensuse.org/download/package?package=osc&project=openSUSE%3ATools
+#
+# Licensed under the terms of the GNU General Public License as published
+# by the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.  You may obtain a copy of the
+# license at
+#
+#    https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+[ -f "${HOME}/.pwmon-rc" ] && source "${HOME}/.pwmon-rc"
+
+source $(dirname $0)/obs_lib.sh
+source $(dirname $0)/series_db_lib.sh
+
+if [ "$1" != "" ]; then
+    pw_instance="$1"
+    shift
+fi
+
+if [ "$1" != "" ]; then
+    obs_user="$1"
+    shift
+fi
+
+if [ "$1" != "" ]; then
+    obs_password="$1"
+    shift
+fi
+
+function submit_result() {
+    echo "pw|$1|$2|$3|$4"
+}
+
+function process_build() {
+    local series_id="$1"
+    local build_state="$2"
+    local build_state_details="$3"
+    local build_url="$4"
+
+    echo "build state [$build_state]"
+    if [ "$build_state" == "scheduled" ]; then
+        return
+    fi
+
+    if [ "$build_state" == "building" ]; then
+        return
+    fi
+
+    if [ "$build_state" == "failed" -o "$build_state" == "succeeded" -o "$build_state" == "errored" ]; then
+        echo "submit..."
+        submit_result "$series_id" "$build_state" "$build_state_details" "$build_url"
+        return
+    fi
+}
+
+mkdir -p ~/.config/osc
+cat << EOF > ~/.config/osc/oscrc
+[general]
+apiurl = https://api.opensuse.org
+build-jobs = 2
+no_verify = 1
+[https://api.opensuse.org]
+aliases = obs
+user=${obs_user}
+pass=${obs_password}
+credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+EOF
+
+echo "looking for active branches"
+
+for branch in $(series_get_active_branches "$pw_instance"); do
+    series_id=$(echo $branch | cut -d\| -f1)
+    branchname=$(echo $branch | cut -d\| -f5)
+    obs_project=$(echo $branch | cut -d\| -f6)
+
+    echo "found active branch $branch"
+    echo "getting results from $obs_project $branchname"
+
+    obs_results_for_package "$obs_project" "$branchname" | \
+        while IFS=\| read -r build_state build_state_details build_url; do
+
+        # try to go by series first
+        echo Checking series $series_id
+        echo "with details ${build_state_details}"
+        echo "and url ${build_url}"
+        process_build "$series_id" "$build_state" "$build_state_details" "$build_url"
+    done
+
+done

--- a/series_set_branch
+++ b/series_set_branch
@@ -1,6 +1,7 @@
 #!/bin/bash
 # SPDX-Identifier: gpl-2.0-or-later
 # Copyright (C) 2019, Red Hat, Inc.
+# Copyright (C) 2020 PANTHEON.tech s.r.o.
 #
 # Licensed under the terms of the GNU General Public License as published
 # by the Free Software Foundation; either version 2 of the License, or
@@ -40,9 +41,14 @@ elif [ "$1" != "" ]; then
     shift
 fi
 
+if [ "$1" != "" ]; then
+    series_obs_project="$1"
+    shift
+fi
+
 if [ "X$pw_instance" == "X" -o "X$series_id" == "X" ]; then
    echo "ERROR: Patchwork instance and series ID are unset."
-   echo "Please invoke as: $0 pw_instance series_id series_repo series_branch"
+   echo "Please invoke as: $0 pw_instance series_id series_repo series_branch series_obs_project"
    exit 1
 fi
 
@@ -50,10 +56,10 @@ echo "ID:     $series_id"
 if ! series_id_exists "$pw_instance" "$series_id"; then
     echo "ERROR: not found on instance $pw_instance"
     exit 1
-fi    
+fi
 
 if [ "X$series_branch" != "X" ]; then
-    series_activate_branch "$pw_instance" "$series_id" "$series_branch" "$series_repo"
+    series_activate_branch "$pw_instance" "$series_id" "$series_branch" "$series_repo" "$series_obs_project"
 else
     series_clear_branch "$pw_instance" "$series_id"
 fi


### PR DESCRIPTION
The Pull Request attempts to add support for Suse OBS to dpdk. I modeled my changes based on travis code, but there are some differences which I want to ask about:

- The OBS code assumes that the utility osc has been installed on the host, obs_mon contains a link to installation instructions - is this okay?

- I'm passing OBS username and password in the scripts and creating ~/.config/osc/oscrc with that. Not sure this is the best way to do this - we could just put the file into the repo or maybe even do something else

- I added series_obs_project to the database since I followed travis code, but this creates a dependency on obs (as does travis). Not sure if this is right